### PR TITLE
Bump Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.6'
+ruby '2.7.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.2'


### PR DESCRIPTION
Prevents:

![image](https://user-images.githubusercontent.com/132/130616776-268edbc8-e431-46e2-bbf0-290859937c90.png)

Following: https://github.com/lewagon/from-design-to-code-boilerplate/pull/8#issuecomment-904548570

